### PR TITLE
feat(auth): force password change on login without storing session

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,7 +18,6 @@ import AccountPage from './page/AccountPage.jsx';
 import UserDetailPage from './page/UserDetailPage.jsx';
 import AdminRoute from './router/AdminRoute.jsx';
 import SuperRoute from './router/SuperRoute.jsx';
-import ForcedPasswordChangeDialog from './component/mypage/ForcedPasswordChangeDialog.jsx';
 import SiteManagementPage from './page/SiteManagementPage.jsx';
 import SiteDetailPage from './page/SiteDetailPage.jsx';
 import QueueStatisticsSkeleton from './component/QueueStatisticsSkeleton.jsx';
@@ -29,7 +28,6 @@ const QueueStatisticsPage = lazy(() => import('./page/QueueStatisticsPage.jsx'))
 function App() {
   return (
     <>
-      <ForcedPasswordChangeDialog />
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signin" element={<SigninPage />} />

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -43,12 +43,16 @@ commonAxiosInstance.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
+    // 초기화 필요 계정은 세션을 유지하지 않는다. 토큰/유저 상태를 비우고 로그인으로 보낸다.
     if (
       error.response?.status === 403
       && error.response?.data?.message === 'Password reset required.'
     ) {
-      const currentUser = useUserStore.getState().user ?? {};
-      useUserStore.getState().setUser({ ...currentUser, passwordResetRequired: true });
+      LoginUtil.clearAccessToken();
+      useUserStore.getState().clearUser();
+      if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
       return Promise.reject(error);
     }
 

--- a/src/api/user/index.js
+++ b/src/api/user/index.js
@@ -23,6 +23,19 @@ const changeMyPassword = async (body) => {
   );
 };
 
+/** 로그인 전 강제 비밀번호 변경 (비인증, 토큰 발급 없음) */
+const changeRequiredPassword = async (body) => {
+  return await publicAxiosInstance.post(`/users/password/change-required`, body, {
+    withCredentials: true,
+  }).then(
+    (response) => response,
+    (error) => {
+      console.error(error);
+      return error.response;
+    }
+  );
+};
+
 const updateMyProfile = (body) => commonAxiosInstance.put('/users/me', body);
 
 const signin = async (body) => {
@@ -74,6 +87,7 @@ const UserClient = {
   me,
   updateMyProfile,
   changeMyPassword,
+  changeRequiredPassword,
   login,
   signin,
   logout,

--- a/src/component/mypage/ForcedPasswordChangeDialog.jsx
+++ b/src/component/mypage/ForcedPasswordChangeDialog.jsx
@@ -1,21 +1,35 @@
 import { Button, FieldError, Form, Input, Label, Modal, TextField } from '@heroui/react';
-import { useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useEffect, useState } from 'react';
 import { UserClient } from '../../api/user/index.js';
-import { useUserStore } from '../../store/user.jsx';
 import { ToastUtil } from '../../util/toastUtil.js';
 
-export default function ForcedPasswordChangeDialog() {
-  const navigate = useNavigate();
-  const user = useUserStore((state) => state.user);
-  const setUser = useUserStore((state) => state.setUser);
-  const [currentPassword, setCurrentPassword] = useState('');
+/**
+ * 로그인 전 강제 비밀번호 변경 다이얼로그.
+ * 세션/토큰 없이 동작하며, 상태는 호출측(LoginPage)의 React state에만 존재한다.
+ */
+export default function ForcedPasswordChangeDialog({
+  isOpen = false,
+  loginId = '',
+  initialCurrentPassword = '',
+  onClose,
+  onSuccess,
+}) {
+  const [currentPassword, setCurrentPassword] = useState(initialCurrentPassword);
   const [newPassword, setNewPassword] = useState('');
   const [newPasswordConfirm, setNewPasswordConfirm] = useState('');
   const [passwordErrors, setPasswordErrors] = useState({});
   const [isPending, setIsPending] = useState(false);
 
-  if (!user?.passwordResetRequired) return null;
+  useEffect(() => {
+    if (!isOpen) return;
+    setCurrentPassword(initialCurrentPassword || '');
+    setNewPassword('');
+    setNewPasswordConfirm('');
+    setPasswordErrors({});
+    setIsPending(false);
+  }, [isOpen, initialCurrentPassword]);
+
+  if (!isOpen) return null;
 
   const clearPasswordError = (name) => {
     setPasswordErrors((current) => {
@@ -54,7 +68,11 @@ export default function ForcedPasswordChangeDialog() {
     setPasswordErrors({});
     setIsPending(true);
     try {
-      const response = await UserClient.changeMyPassword({ currentPassword, newPassword });
+      const response = await UserClient.changeRequiredPassword({
+        loginId,
+        currentPassword,
+        newPassword,
+      });
       if (response?.status !== 200) {
         ToastUtil.error(
           '비밀번호 변경',
@@ -63,13 +81,12 @@ export default function ForcedPasswordChangeDialog() {
         return;
       }
 
-      setUser(response.data);
       setCurrentPassword('');
       setNewPassword('');
       setNewPasswordConfirm('');
       setPasswordErrors({});
-      ToastUtil.success('비밀번호 변경 완료', '새로운 비밀번호로 로그인이 완료되었습니다.');
-      navigate('/', { replace: true });
+      ToastUtil.success('비밀번호 변경 완료', '새 비밀번호로 다시 로그인해 주세요.');
+      onSuccess?.();
     } catch (error) {
       console.error(error);
       ToastUtil.error(
@@ -92,10 +109,10 @@ export default function ForcedPasswordChangeDialog() {
             <Form onSubmit={changePassword} validationErrors={passwordErrors}>
               <Modal.Body className="flex flex-col gap-4 pt-2">
                 <p className="text-sm text-muted">
-                  관리자가 비밀번호를 초기화했습니다. 새로운 비밀번호로 변경해야 로그인 할 수 있습니다.
+                  관리자가 비밀번호를 초기화했습니다. 새로운 비밀번호로 변경한 뒤 다시 로그인해 주세요.
                 </p>
                 <TextField name="currentPassword" isRequired>
-                  <Label className="text-base">현재 비밀번호</Label>
+                  <Label className="text-base">현재 비밀번호 (임시 비밀번호)</Label>
                   <Input
                     className="ring-1 focus:ring-2 ring-neutral-200 focus:ring-accent"
                     type="password"
@@ -138,9 +155,14 @@ export default function ForcedPasswordChangeDialog() {
                   <FieldError>{passwordErrors.newPasswordConfirm ?? '신규 비밀번호 확인을 입력해 주세요.'}</FieldError>
                 </TextField>
               </Modal.Body>
-              <Modal.Footer className="pb-[max(1rem,env(safe-area-inset-bottom))]">
+              <Modal.Footer className="flex flex-col gap-2 pb-[max(1rem,env(safe-area-inset-bottom))] sm:flex-row">
+                {typeof onClose === 'function' && (
+                  <Button type="button" variant="secondary" className="min-h-11 w-full" onPress={onClose}>
+                    취소
+                  </Button>
+                )}
                 <Button type="submit" isPending={isPending} className="min-h-11 w-full">
-                  변경하고 로그인
+                  변경하기
                 </Button>
               </Modal.Footer>
             </Form>

--- a/src/page/LoginPage.jsx
+++ b/src/page/LoginPage.jsx
@@ -7,6 +7,10 @@ import { UserClient } from '../api/user/index.js';
 import { ToastUtil } from '../util/toastUtil.js';
 import { usePreferenceStore } from '../store/preference.jsx';
 import { useUserStore } from '../store/user.jsx';
+import ForcedPasswordChangeDialog from '../component/mypage/ForcedPasswordChangeDialog.jsx';
+
+const isPasswordResetRequiredResponse = (response) =>
+  response?.status === 403 && response?.data?.message === 'Password reset required.';
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -15,6 +19,8 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [rememberUser, setRememberUser] = useState(false);
   const [errors, setErrors] = useState({});
+  const [passwordResetOpen, setPasswordResetOpen] = useState(false);
+  const [pendingReset, setPendingReset] = useState(null);
   const { updateLoginPreference } = usePreferenceStore();
 
   const { setUser } = useUserStore();
@@ -33,6 +39,13 @@ export default function LoginPage() {
     }
 
     const response = await UserClient.login({ loginId, password, autoLogin: rememberUser });
+
+    // 비밀번호 초기화 필요: 토큰/userStorage에 저장하지 않고 다이얼로그만 표시 (새로고침 시 소멸)
+    if (isPasswordResetRequiredResponse(response)) {
+      setPendingReset({ loginId, currentPassword: password });
+      setPasswordResetOpen(true);
+      return;
+    }
 
     if (response.status === 401 || response.status === 403 || response.status === 404) {
       ToastUtil.error('로그인 실패', response?.data?.detail || '아이디 또는 비밀번호가 잘못되었습니다.');
@@ -58,14 +71,21 @@ export default function LoginPage() {
 
     updateLoginPreference({ autoLogin: rememberUser });
 
-    if (loginResponse.data?.passwordResetRequired) {
-      return;
-    }
-
     const params = new URLSearchParams(search);
     const to = params.get('redirect') || '/'; // redirect가 있다면 해당 url로 없다면 /로 이동
 
     navigate(to);
+  };
+
+  const handlePasswordResetSuccess = () => {
+    setPasswordResetOpen(false);
+    setPendingReset(null);
+    setPassword('');
+  };
+
+  const handlePasswordResetClose = () => {
+    setPasswordResetOpen(false);
+    setPendingReset(null);
   };
 
   useEffect(() => {
@@ -125,6 +145,14 @@ export default function LoginPage() {
 
         <Card.Footer></Card.Footer>
       </Card>
+
+      <ForcedPasswordChangeDialog
+        isOpen={passwordResetOpen}
+        loginId={pendingReset?.loginId ?? ''}
+        initialCurrentPassword={pendingReset?.currentPassword ?? ''}
+        onClose={handlePasswordResetClose}
+        onSuccess={handlePasswordResetSuccess}
+      />
     </main>
   );
 }


### PR DESCRIPTION
Open the reset dialog from LoginPage only after a password-reset-required response, call the public change API, and clear any partial auth instead of persisting userStorage.